### PR TITLE
string containing \x00 raises unexpected exception.

### DIFF
--- a/blake2/blake2module.c
+++ b/blake2/blake2module.c
@@ -11,12 +11,14 @@ static PyObject * blake2b_func(PyObject *self, PyObject *args,  PyObject *keywds
 {
 
     char *data;
+    int data_length;
+    int key_length ;
     long hashSize = BLAKE2B_OUTBYTES;
     char *key = "";
     int rawOutput = 1 ;
     static char *kwlist[] = {"data","hashSize", "key", "rawOutput", NULL};
 
-    if (!PyArg_ParseTupleAndKeywords(args, keywds, "z|ish", kwlist, &data, &hashSize, &key, &rawOutput)){
+    if (!PyArg_ParseTupleAndKeywords(args, keywds, "z#|is#h", kwlist, &data, &data_length, &hashSize, &key, &key_length, &rawOutput)){
 	Py_INCREF(Py_None);
 	return Py_None;
     }
@@ -28,14 +30,6 @@ static PyObject * blake2b_func(PyObject *self, PyObject *args,  PyObject *keywds
 
     char outputHash[ hashSize ];
     int result ;
-    int data_length = strlen(data);
-    int key_length ;
-    if( NULL == key ){
-	 key_length = 0;
-    }
-    else {
-	key_length = strlen(key);
-    }
 
     if ( ! ((  hashSize  > 0 ) && ( hashSize <= 64 ))){
         PyErr_SetString(Blake2HashSizeError, "hashSize error");
@@ -63,12 +57,14 @@ static PyObject * blake2s_func(PyObject *self, PyObject *args,  PyObject *keywds
 {
 
     char *data;
+    int data_length;
+    int key_length ;
     long hashSize = BLAKE2S_OUTBYTES;
     char *key = "";
     int rawOutput = 1 ;
     static char *kwlist[] = {"data","hashSize", "key", "rawOutput", NULL};
 
-    if (!PyArg_ParseTupleAndKeywords(args, keywds, "z|ish", kwlist, &data, &hashSize, &key, &rawOutput)){
+    if (!PyArg_ParseTupleAndKeywords(args, keywds, "z#|is#h", kwlist, &data, &data_length, &hashSize, &key, &key_length, &rawOutput)){
 	Py_INCREF(Py_None);
 	return Py_None;
     }
@@ -80,14 +76,6 @@ static PyObject * blake2s_func(PyObject *self, PyObject *args,  PyObject *keywds
 
     char outputHash[ hashSize ];
     int result ;
-    int data_length = strlen(data);
-    int key_length ;
-    if( NULL == key ){
-	 key_length = 0;
-    }
-    else {
-	key_length = strlen(key);
-    }
 
     if ( ! ((  hashSize  > 0 ) && ( hashSize <= 32 ))){
         PyErr_SetString(Blake2HashSizeError, "hashSize error");

--- a/blake2test/test.py
+++ b/blake2test/test.py
@@ -25,7 +25,7 @@ def blake2s():
     assert blake2.blake2s("hello world", hashSize=16, key="hello world") == '4e989fc7739d052dd93ec88962137c08'
     assert blake2.blake2s("hello world", hashSize=4, key="hello world") == 'fef7f902'
     assert blake2.blake2s("hello\x00world", key="hello\x00world") == '36429945e82aec7853fd2bd1c7349a65e4457db81c059b287f7a859e3b26e3f4'
-    assert blake2.blake2(None) == None
+    assert blake2.blake2s(None) == None
 
 
 

--- a/blake2test/test.py
+++ b/blake2test/test.py
@@ -13,6 +13,7 @@ def blake2b():
     assert blake2.blake2("hello world", hashSize=32, key="hello world") == '177a8d7754e0aaa6645179c6c9933c3c57a4880e91223f56ded5d3e3cd7144dd'
     assert blake2.blake2("hello world", hashSize=16, key="hello world") == '8fe7d57f5c53d8afd00f552269502b81'
     assert blake2.blake2("hello world", hashSize=4, key="hello world") == 'bbd7cc6e'
+    assert blake2.blake2("hello\x00world", key="hello\x00world") == 'e06e51bbdc12363243a55ddc23aaeb310faceec72e21d93c85d7e77360aa48cb6baf2963661bf857b1686c89f5dd209f0abee10aa2e38d0318043718976bcb60'
     assert blake2.blake2(None) == None
 
 
@@ -23,6 +24,7 @@ def blake2s():
     assert blake2.blake2s("hello world", key="hello world") == '846d7f4e70f94df2b07e2f5d59d271d5b4627ab64cc0fc376f411448528bee49'
     assert blake2.blake2s("hello world", hashSize=16, key="hello world") == '4e989fc7739d052dd93ec88962137c08'
     assert blake2.blake2s("hello world", hashSize=4, key="hello world") == 'fef7f902'
+    assert blake2.blake2s("hello\x00world", key="hello\x00world") == '36429945e82aec7853fd2bd1c7349a65e4457db81c059b287f7a859e3b26e3f4'
     assert blake2.blake2(None) == None
 
 


### PR DESCRIPTION
string containing \x00 is being mishandled by `strlen()`, because `strlen()` only counts from start to  NULL(\x00).

On the current version, I could get these error messages:

```
>>> blake2.blake2('\x00')
>>> 
TypeError: argument 1 must be string without null bytes or None, not str
```

Thus I changed some codes, please check this out.

p.s. I also added some test codes for your convenience. ^^
