### PR TITLE
`key_length` must have a default value.

### DIFF
--- a/blake2/blake2module.c
+++ b/blake2/blake2module.c
@@ -12,7 +12,7 @@ static PyObject * blake2b_func(PyObject *self, PyObject *args,  PyObject *keywds
 
     char *data;
     int data_length;
-    int key_length ;
+    int key_length = 0;
     long hashSize = BLAKE2B_OUTBYTES;
     char *key = "";
     int rawOutput = 1 ;
@@ -58,7 +58,7 @@ static PyObject * blake2s_func(PyObject *self, PyObject *args,  PyObject *keywds
 
     char *data;
     int data_length;
-    int key_length ;
+    int key_length = 0;
     long hashSize = BLAKE2S_OUTBYTES;
     char *key = "";
     int rawOutput = 1 ;

--- a/blake2test/test.py
+++ b/blake2test/test.py
@@ -14,6 +14,7 @@ def blake2b():
     assert blake2.blake2("hello world", hashSize=16, key="hello world") == '8fe7d57f5c53d8afd00f552269502b81'
     assert blake2.blake2("hello world", hashSize=4, key="hello world") == 'bbd7cc6e'
     assert blake2.blake2("hello\x00world", key="hello\x00world") == 'e06e51bbdc12363243a55ddc23aaeb310faceec72e21d93c85d7e77360aa48cb6baf2963661bf857b1686c89f5dd209f0abee10aa2e38d0318043718976bcb60'
+    assert blake2.blake2('\x00') == blake2.blake2('\x00')
     assert blake2.blake2(None) == None
 
 
@@ -25,6 +26,7 @@ def blake2s():
     assert blake2.blake2s("hello world", hashSize=16, key="hello world") == '4e989fc7739d052dd93ec88962137c08'
     assert blake2.blake2s("hello world", hashSize=4, key="hello world") == 'fef7f902'
     assert blake2.blake2s("hello\x00world", key="hello\x00world") == '36429945e82aec7853fd2bd1c7349a65e4457db81c059b287f7a859e3b26e3f4'
+    assert blake2.blake2s('\x00') == blake2.blake2s('\x00')
     assert blake2.blake2s(None) == None
 
 


### PR DESCRIPTION
When `key` is `None`, `key_length` wouldn't be set by `PyArg_ParseTupleAndKeywords`, since format `s` doesn't accept `None`.
Thus I added a proper default value for it, and also test case for it.
